### PR TITLE
Use for loop instead of forEach in vocab response

### DIFF
--- a/apps/cwb/controllers/project.js
+++ b/apps/cwb/controllers/project.js
@@ -27,9 +27,9 @@ CWB.projectController = SC.ObjectController.create({
             .notify(this, function(response, that) {
                 if (SC.ok(response)) {
                     CWB.VOCABULARIES = response.get('body') || [];
-                    CWB.VOCABULARIES.forEach(function(vocab, index) {
-												that.getTermsForVocabulary(index);
-                    });
+                    for(var i = 0; i < CWB.VOCABULARIES.length; i++) {
+                      that.getTermsForVocabulary(i);
+                    }
                 } else {
                     console.warn('Sorry, we were unable to fetch vocabularies for project: ' + projectID);
                     CWB.VOCABULARIES = [];


### PR DESCRIPTION
`forEach` doesn't quite have 100% browser support yet so let's change this to a traditional `for` loop and see if that makes a difference on the issue we're seeing here: https://cyber.law.harvard.edu/projectmanagement/issues/11288
